### PR TITLE
build: upgrade action versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Add problem matcher'
         run: echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create Release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
+        run: |
+          gh release create ${{ github.ref }} \
+            --repo="${{ github.repository }}" \
+            --title "Release ${{ github.ref }}" \
+            --generate-notes \
+            --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create Release
         uses: actions/create-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Output cache metadata'
         id: cache_metadata
@@ -62,7 +62,7 @@ jobs:
     needs: [ build_cache ]
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
         uses: actions/setup-node@v3
@@ -94,7 +94,7 @@ jobs:
     needs: [ build_cache ]
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
         uses: actions/setup-node@v3
@@ -130,7 +130,7 @@ jobs:
     needs: [ build_cache ]
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
         uses: actions/setup-node@v3
@@ -173,7 +173,7 @@ jobs:
       - check_dist
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Post summary'
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 'Use Node ${{ env.NODE_VERSION }}'
         if: steps.yarn_cache.outputs.cache-hit != 'true' || steps.modules_cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Use Node.js ${{ env.NODE_VERSION }}'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: 'Check for existing yarn cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn_cache
         with:
           key: ${{ steps.cache_metadata.outputs.key }}
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 'Check for existing node_modules cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: modules_cache
         with:
           key: ${{ steps.cache_metadata.outputs.key }}
@@ -70,7 +70,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: 'Restore yarn cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.yarn_path }}
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 'Restore node_modules cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.modules_path }}
@@ -102,7 +102,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: 'Get yarn cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.yarn_path }}
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 'Get node modules cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.modules_path }}
@@ -138,7 +138,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: 'Get yarn cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.yarn_path }}
@@ -146,7 +146,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 'Get node modules cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ needs.build_cache.outputs.key }}
           path: ${{ needs.build_cache.outputs.modules_path }}


### PR DESCRIPTION
- Upgrade versions of actions that were using the deprecated node 16 runtime
- Remove reference to the archived `actions/create-release` action - use the `gh` CLI instead